### PR TITLE
Instance Checking

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -17,6 +17,7 @@ relatively low. Its `Dtype[ArrayClass, "{shape_expression}"]` syntax is not well
 suited for modeling arrays intended to be general across implementations, and 
 makes it challenging to adapt to pydantic's schema generation system.
 
+(design_challenges)=
 ## Challenges
 
 The Python type annotation system is weird and not like the rest of Python! 

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,25 @@ model = MyModel(array=('data.zarr', '/nested/dataset'))
 model = MyModel(array="data.mp4")
 ```
 
+And use the `NDArray` type annotation like a regular type outside
+of pydantic -- eg. to validate an array anywhere, use `isinstance`:
+
+```python
+array_type = NDArray[Shape["1, 2, 3"], int]
+isinstance(np.zeros((1,2,3), dtype=int), array_type)
+# True
+isinstance(zarr.zeros((1,2,3), dtype=int), array_type)
+# True
+isinstance(np.zeros((4,5,6), dtype=int), array_type)
+# False
+isinstance(np.zeros((1,2,3), dtype=float), array_type)
+# False
+```
+
+```{note}
+`NDArray` can't do validation with static type checkers yet, see 
+{ref}`design_challenges` and {ref}`type_checkers`
+```
 
 ## Features:
 - **Types** - Annotations (based on [npytyping](https://github.com/ramonhagenaars/nptyping))

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -10,6 +10,21 @@ type system and is no longer actively maintained. We will be reimplementing a sy
 that extends its array specification syntax to include things like ranges and extensible
 dtypes with varying precision (and is much less finnicky to deal with).
 
+(type_checkers)=
+## Type Checker Integration
+
+The `.pyi` stubfile generation ({mod}`numpydantic.meta`) works for 
+keeping type checkers from complaining about various array formats
+not literally being `NDArray` objects, but it doesn't do the kind of 
+validation we would want to be able to use `NDArray` objects as full-fledged
+python types, including validation propagation through scopes and 
+IDE type checking for invalid literals.
+
+We want to hook into the type checking process to satisfy these type checkers:
+- mypy - has hooks, can be done with an extension
+- pyright - unclear if has hooks, might nee to monkeypatch
+- pycharm - unlikely this is possible, extensions need to be in Java and installed separately
+
 
 ## Validation
 

--- a/src/numpydantic/exceptions.py
+++ b/src/numpydantic/exceptions.py
@@ -3,9 +3,25 @@ Exceptions used within numpydantic
 """
 
 
-class DtypeError(TypeError):
+class InterfaceError(Exception):
+    """Parent mixin class for errors raised by :class:`.Interface` subclasses"""
+
+
+class DtypeError(TypeError, InterfaceError):
     """Exception raised for invalid dtypes"""
 
 
-class ShapeError(ValueError):
+class ShapeError(ValueError, InterfaceError):
     """Exception raise for invalid shapes"""
+
+
+class MatchError(ValueError, InterfaceError):
+    """Exception for errors raised during :class:`.Interface.match`-ing"""
+
+
+class NoMatchError(MatchError):
+    """No match was found by :class:`.Interface.match`"""
+
+
+class TooManyMatchesError(MatchError):
+    """Too many matches found by :class:`.Interface.match`"""

--- a/src/numpydantic/meta.py
+++ b/src/numpydantic/meta.py
@@ -24,7 +24,8 @@ def generate_ndarray_stub() -> str:
         # Create import statements, saving aliased name of type if needed
         if arr.__module__.startswith("numpydantic") or arr.__module__ == "typing":
             type_name = str(arr) if arr.__module__ == "typing" else arr.__name__
-            import_strings.append(f"from {arr.__module__} import {type_name}")
+            if arr.__module__ != "typing":
+                import_strings.append(f"from {arr.__module__} import {type_name}")
         else:
             # since other packages could use the same name for an imported object
             # (eg dask and zarr both use an Array class)
@@ -39,6 +40,7 @@ def generate_ndarray_stub() -> str:
         type_names.append(type_name)
 
     import_strings.extend(_BUILTIN_IMPORTS)
+    import_strings = list(dict.fromkeys(import_strings))
     import_string = "\n".join(import_strings)
 
     class_union = " | ".join(type_names)

--- a/src/numpydantic/ndarray.py
+++ b/src/numpydantic/ndarray.py
@@ -39,7 +39,7 @@ from numpydantic.schema import (
 )
 from numpydantic.types import DtypeType, ShapeType
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from nptyping.base_meta_classes import SubscriptableMeta
 
 
@@ -49,7 +49,7 @@ class NDArrayMeta(_NDArrayMeta, implementation="NDArray"):
     completion of the transition away from nptyping
     """
 
-    if TYPE_CHECKING:
+    if TYPE_CHECKING:  # pragma: no cover
         __getitem__ = SubscriptableMeta.__getitem__
 
     def __instancecheck__(self, instance: Any):

--- a/src/numpydantic/schema.py
+++ b/src/numpydantic/schema.py
@@ -225,7 +225,9 @@ def get_validate_interface(shape: ShapeType, dtype: DtypeType) -> Callable:
     :meth:`.Interface.validate` method
     """
 
-    def validate_interface(value: Any, info: "ValidationInfo") -> NDArrayType:
+    def validate_interface(
+        value: Any, info: Optional["ValidationInfo"] = None
+    ) -> NDArrayType:
         interface_cls = Interface.match(value)
         interface = interface_cls(shape, dtype)
         value = interface.validate(value)

--- a/tests/test_ndarray.py
+++ b/tests/test_ndarray.py
@@ -223,3 +223,23 @@ def test_json_schema_ellipsis():
 
     schema = ConstrainedAnyShape.model_json_schema()
     _recursive_array(schema)
+
+
+def test_instancecheck():
+    """
+    NDArray should handle ``isinstance()`` s.t. valid arrays are ``True``
+    and invalid arrays are ``False``
+
+    We don't make this test exhaustive because correctness of validation
+    is tested elsewhere. We are just testing that the type checking works
+    """
+    array_type = NDArray[Shape["1, 2, 3"], int]
+
+    assert isinstance(np.zeros((1, 2, 3), dtype=int), array_type)
+    assert not isinstance(np.zeros((2, 2, 3), dtype=int), array_type)
+    assert not isinstance(np.zeros((1, 2, 3), dtype=float), array_type)
+
+    def my_function(array: NDArray[Shape["1, 2, 3"], int]):
+        return array
+
+    my_function(np.zeros((1, 2, 3), int))


### PR DESCRIPTION
Add the ability to do `isinstance(array, NDArray[])` including validations :)

Also:

Params:
- add `fast` matching mode that returns the first match without checking for duplicate matches

Bugfix:
- get all interface classes recursively, instead of just first-layer children 
- fix stubfile generation which badly handled `typing` imports.