### PR TITLE
Better string dtype handling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
 
       - name: Install dependencies
         run: pip install -e ".[tests]"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,17 @@
 
 ## 1.*
 
+### 1.3.0 - 24-08-05 - Better string dtype handling
+
+API Changes:
+- Split apart the validation methods into smaller chunks to better support
+  overrides by interfaces. Customize getting and raising errors for dtype and shape,
+  as well as separation of concerns between getting, validating, and raising.
+
+Bugfix:
+- [#4](https://github.com/p2p-ld/numpydantic/issues/4) - Support dtype checking
+  for strings in zarr and numpy arrays
+
 ### 1.2.3 - 24-07-31 - Vendor `nptyping`
 
 `nptyping` vendored into `numpydantic.vendor.nptyping` - 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -41,19 +41,42 @@ when cast to an `ndarray`, we only try as a last resort.
 
 ## Validation
 
-Validation is a chain of lifecycle methods, with a single argument passed and returned
-to and from each:
+Validation is a chain of lifecycle methods, each of which can be overridden
+for interfaces to implement custom behavior that matches the array format.
 
-{meth}`.Interface.validate` calls in order:
+{meth}`.Interface.validate` calls the following methods, in order:
+
+An initial hook for modifying the input data before validation, eg.
+if it needs to be coerced or wrapped in some proxy class. This method
+should accept all and only the types specified in that interface's
+{attr}`~.Interface.input_types`.
 
 - {meth}`.Interface.before_validation`
-- {meth}`.Interface.validate_dtype`
-- {meth}`.Interface.validate_shape`
-- {meth}`.Interface.after_validation`
 
-The `before` and `after` methods provide hooks for coercion, loading, etc. such that
-`validate` can accept one of the types in the interface's 
-{attr}`~.Interface.input_types` and return the {attr}`~.Interface.return_type` .
+A cluster of methods for validating dtype.
+Separating these methods allow for array formats that store dtype information
+in a nonstandard attribute, require additional coercion, or for implementing
+custom exception handlers or rescuers.
+Check the method signatures and return types
+when overriding and the docstrings for details.
+
+- {meth}`.Interface.get_dtype`
+- {meth}`.Interface.validate_dtype`
+- {meth}`.Interface.raise_for_dtype`
+
+A halftime hook for modifying the array or bailing early between validation phases.
+
+- {meth}`.Interface.after_validate_dtype`
+
+A cluster of methods for validating shape, similar to the dtype cluster.
+
+- {meth}`.Interface.get_shape`
+- {meth}`.Interface.validate_shape`
+- {meth}`.Interface.raise_for_shape`
+
+A final hook for modifying the array before passing it to be assigned to the field.
+This method should return an object matching the interface's {attr}`~.Interface.return_type`.
+- {meth}`.Interface.after_validation`
 
 ## Diagram
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "numpydantic"
-version = "1.2.3"
+version = "1.3.0"
 description = "Type and shape validation and serialization for numpy arrays in pydantic models"
 authors = [
     {name = "sneakers-the-rat", email = "sneakers-the-rat@protonmail.com"},

--- a/src/numpydantic/interface/interface.py
+++ b/src/numpydantic/interface/interface.py
@@ -62,7 +62,7 @@ class Interface(ABC, Generic[T]):
         * :meth:`.after_validation` - hook after validation for modifying the array
             that is set as the model field value
 
-        Follow the method signatures and return types to override 
+        Follow the method signatures and return types to override.
 
         Implementing an interface subclass largely consists of overriding these methods
         as needed.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,7 @@ RGB_UNION: TypeAlias = Union[
 NUMBER: TypeAlias = NDArray[Shape["*, *, *"], Number]
 INTEGER: TypeAlias = NDArray[Shape["*, *, *"], Integer]
 FLOAT: TypeAlias = NDArray[Shape["*, *, *"], Float]
+STRING: TypeAlias = NDArray[Shape["*, *, *"], str]
 
 
 @pytest.fixture(
@@ -121,10 +122,15 @@ def shape_cases(request) -> ValidationCase:
         ValidationCase(annotation=INTEGER, dtype=np.uint8, passes=True),
         ValidationCase(annotation=INTEGER, dtype=float, passes=False),
         ValidationCase(annotation=INTEGER, dtype=np.float32, passes=False),
+        ValidationCase(annotation=INTEGER, dtype=str, passes=False),
         ValidationCase(annotation=FLOAT, dtype=float, passes=True),
         ValidationCase(annotation=FLOAT, dtype=np.float32, passes=True),
         ValidationCase(annotation=FLOAT, dtype=int, passes=False),
         ValidationCase(annotation=FLOAT, dtype=np.uint8, passes=False),
+        ValidationCase(annotation=FLOAT, dtype=str, passes=False),
+        ValidationCase(annotation=STRING, dtype=str, passes=True),
+        ValidationCase(annotation=STRING, dtype=int, passes=False),
+        ValidationCase(annotation=STRING, dtype=float, passes=False),
     ],
     ids=[
         "float",
@@ -139,10 +145,15 @@ def shape_cases(request) -> ValidationCase:
         "integer-uint8",
         "integer-float",
         "integer-float32",
+        "integer-str",
         "float-float",
         "float-float32",
         "float-int",
         "float-uint8",
+        "float-str",
+        "str-str",
+        "str-int",
+        "str-float",
     ],
 )
 def dtype_cases(request) -> ValidationCase:


### PR DESCRIPTION
Fix: https://github.com/p2p-ld/numpydantic/issues/4

Strings now validate correctly for numpy and zarr. hdf5 strings are still unsupported.

Additionally, more fine-grained control over validation :)