### PR TITLE
Support `len()` across all interfaces

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,22 @@
 
 ## 1.*
 
+### 1.4.1 - 24-09-02 - `len()` support and dunder method testing
+
+It's pretty natural to want to do `len(array)` as a shorthand for `array.shape[0]`, 
+but since some of the numpydantic classes are passthrough proxy objects, 
+they don't implement all the dunder methods of the classes they wrap 
+(though they should attempt to via `__getattr__`). 
+
+This PR adds `__len__` to the two interfaces that are missing it, 
+and adds fixtures and makes a testing module specifically for testing dunder methods 
+that should be true across all interfaces. 
+Previously we have had fixtures that test all of a set of dtype and shape cases for each interface,
+but we haven't had a way of asserting that something should be true for all interfaces. 
+There is a certain combinatoric explosion when we start testing across all interfaces, 
+for all input types, for all dtype and all shape cases, 
+but for now numpydantic is fast enough that this doesn't matter <3.
+
 ### 1.4.0 - 24-09-02 - HDF5 Compound Dtype Support
 
 HDF5 can have compound dtypes like:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "numpydantic"
-version = "1.4.0"
+version = "1.4.1"
 description = "Type and shape validation and serialization for numpy arrays in pydantic models"
 authors = [
     {name = "sneakers-the-rat", email = "sneakers-the-rat@protonmail.com"},

--- a/src/numpydantic/interface/hdf5.py
+++ b/src/numpydantic/interface/hdf5.py
@@ -121,6 +121,10 @@ class H5Proxy:
                 else:
                     obj[key, self.field] = value
 
+    def __len__(self) -> int:
+        """self.shape[0]"""
+        return self.shape[0]
+
     def open(self, mode: str = "r") -> "h5py.Dataset":
         """
         Return the opened :class:`h5py.Dataset` object

--- a/src/numpydantic/interface/video.py
+++ b/src/numpydantic/interface/video.py
@@ -180,6 +180,10 @@ class VideoProxy:
     def __getattr__(self, item: str):
         return getattr(self.video, item)
 
+    def __len__(self) -> int:
+        """Number of frames in the video"""
+        return self.shape[0]
+
 
 class VideoInterface(Interface):
     """

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -179,6 +179,4 @@ def avi_video(tmp_path) -> Callable[[Tuple[int, int], int, bool], Path]:
         writer.release()
         return video_path
 
-    yield _make_video
-
-    video_path.unlink(missing_ok=True)
+    return _make_video

--- a/tests/test_interface/test_dunder.py
+++ b/tests/test_interface/test_dunder.py
@@ -1,0 +1,10 @@
+"""
+Tests for dunder methods on all interfaces
+"""
+
+
+def test_dunder_len(all_interfaces):
+    """
+    Each interface or proxy type should support __len__
+    """
+    assert len(all_interfaces.array) == all_interfaces.array.shape[0]

--- a/tests/test_interface/test_video.py
+++ b/tests/test_interface/test_video.py
@@ -2,8 +2,6 @@
 Needs to be refactored to DRY, but works for now
 """
 
-import pdb
-
 import numpy as np
 import pytest
 
@@ -15,37 +13,6 @@ from pydantic import BaseModel, ValidationError
 from numpydantic import NDArray, Shape
 from numpydantic import dtype as dt
 from numpydantic.interface.video import VideoProxy
-
-
-@pytest.fixture(scope="function")
-def avi_video(tmp_path):
-    video_path = tmp_path / "test.avi"
-
-    def _make_video(shape=(100, 50), frames=10, is_color=True) -> Path:
-        writer = cv2.VideoWriter(
-            str(video_path),
-            cv2.VideoWriter_fourcc(*"RGBA"),  # raw video for testing purposes
-            30,
-            (shape[1], shape[0]),
-            is_color,
-        )
-        if is_color:
-            shape = (*shape, 3)
-
-        for i in range(frames):
-            # make fresh array every time bc opencv eats them
-            array = np.zeros(shape, dtype=np.uint8)
-            if not is_color:
-                array[i, i] = i
-            else:
-                array[i, i, :] = i
-            writer.write(array)
-        writer.release()
-        return video_path
-
-    yield _make_video
-
-    video_path.unlink(missing_ok=True)
 
 
 @pytest.mark.parametrize("input_type", [str, Path])


### PR DESCRIPTION
It's pretty natural to want to do `len(array)` as a shorthand for `array.shape[0]`, but since some of the numpydantic classes are passthrough proxy objects, they don't implement all the dunder methods of the classes they wrap (though they should attempt to via `__getattr__`). 

This PR adds `__len__` to the two interfaces that are missing it, and adds fixtures and makes a testing module specifically for testing dunder methods that should be true across all interfaces. Previously we have had fixtures that test all of a set of dtype and shape cases for each interface, but we haven't had a way of asserting that something should be true for all interfaces. There is a certain combinatoric explosion when we start testing across all interfaces, for all input types, for all dtype and all shape cases, but for now numpydantic is fast enough that this doesn't matter <3