### PR TITLE
Support datetimes in hdf5 proxies

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,11 @@
 
 ### 1.5.*
 
+#### 1.5.2 - 24-09-03 - `datetime` support for HDF5
+
+- [#15](https://github.com/p2p-ld/numpydantic/pull/15): Datetimes are supported as 
+  dtype annotations for HDF5 arrays when encoded as `S32` isoformatted byte strings
+
 #### 1.5.1 - 24-09-03 - Fix revalidation with proxy classes
 
 Bugfix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "numpydantic"
-version = "1.5.1"
+version = "1.5.2"
 description = "Type and shape validation and serialization for arbitrary array types in pydantic models"
 authors = [
     {name = "sneakers-the-rat", email = "sneakers-the-rat@protonmail.com"},

--- a/src/numpydantic/interface/hdf5.py
+++ b/src/numpydantic/interface/hdf5.py
@@ -22,6 +22,21 @@ Interfaces for HDF5 Datasets
     To have direct access to the hdf5 dataset, use the
     :meth:`.H5Proxy.open` method.
     
+Datetimes 
+---------
+
+Datetimes are supported as a dtype annotation, but currently they must be stored
+as ``S32`` isoformatted byte strings (timezones optional) like:    
+
+.. code-block:: python
+
+    import h5py
+    from datetime import datetime
+    import numpy as np
+    data = np.array([datetime.now().isoformat().encode('utf-8')], dtype="S32")
+    h5f = h5py.File('test.hdf5', 'w')
+    h5f.create_dataset('data', data=data)
+    
 """
 
 import sys
@@ -311,7 +326,7 @@ class H5Interface(Interface):
                     return np.datetime64
                 else:
                     return str
-            except (AttributeError, ValueError, TypeError):
+            except (AttributeError, ValueError, TypeError):  # pragma: no cover
                 return str
         else:
             return array.dtype

--- a/src/numpydantic/schema.py
+++ b/src/numpydantic/schema.py
@@ -166,7 +166,11 @@ def _hash_schema(schema: CoreSchema) -> str:
     to produce the same hash.
     """
     schema_str = json.dumps(
-        schema, sort_keys=True, indent=None, separators=(",", ":")
+        schema,
+        sort_keys=True,
+        indent=None,
+        separators=(",", ":"),
+        default=lambda x: None,
     ).encode("utf-8")
     hasher = hashlib.blake2b(digest_size=8)
     hasher.update(schema_str)


### PR DESCRIPTION
HDF5 can't support datetimes natively, but we can fake it with 32-bit strings. 

This PR allows one to specify a datetime dtype, and encodes datetime objects as strings on storage, and decodes them on access. 

Getting to the point where we need to start making a generalized type conversion/serialization system because this interface in particular is getting gnarly, but don't have time just yet