### PR TITLE
Serialization direct from proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,5 @@ cython_debug/
 ndarray.pyi
 
 prof/
+
+__tmp__

--- a/src/numpydantic/ndarray.py
+++ b/src/numpydantic/ndarray.py
@@ -13,6 +13,7 @@ Extension of nptyping NDArray for pydantic that allows for JSON-Schema serializa
 
 """
 
+import pdb
 from typing import TYPE_CHECKING, Any, Literal, Tuple, get_origin
 
 import numpy as np
@@ -199,6 +200,7 @@ class NDArray(NPTypingType, metaclass=NDArrayMeta):
         cls, schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
     ) -> core_schema.JsonSchema:
         shape, dtype = cls.__args__
+        pdb.set_trace()
         json_schema = handler(schema["metadata"])
         json_schema = handler.resolve_ref_schema(json_schema)
 

--- a/src/numpydantic/serialization.py
+++ b/src/numpydantic/serialization.py
@@ -16,6 +16,8 @@ U = TypeVar("U")
 
 def jsonize_array(value: Any, info: SerializationInfo) -> Union[list, dict]:
     """Use an interface class to render an array as JSON"""
+    # return [1, 2, 3]
+    # pdb.set_trace()
     interface_cls = Interface.match_output(value)
     array = interface_cls.to_json(value, info)
     array = postprocess_json(array, info)

--- a/src/numpydantic/serialization.py
+++ b/src/numpydantic/serialization.py
@@ -16,11 +16,20 @@ U = TypeVar("U")
 
 def jsonize_array(value: Any, info: SerializationInfo) -> Union[list, dict]:
     """Use an interface class to render an array as JSON"""
-    # perf: keys to skip in generation - anything named "value" is array data.
-    skip = ["value"]
-
     interface_cls = Interface.match_output(value)
     array = interface_cls.to_json(value, info)
+    array = postprocess_json(array, info)
+    return array
+
+
+def postprocess_json(
+    array: Union[dict, list], info: SerializationInfo
+) -> Union[dict, list]:
+    """
+    Modify json after dumping from an interface
+    """
+    # perf: keys to skip in generation - anything named "value" is array data.
+    skip = ["value"]
     if isinstance(array, JsonDict):
         array = array.model_dump(exclude_none=True)
 


### PR DESCRIPTION
Problem: sometimes pydantic loses the `NDArray` annotation and needs to be able to serialize directly from proxy objects, eg. when used as an `Extra` annotation or otherwise. 

This PR ensures that all proxy objects can also roundtrip directly

