### PR TITLE
[ux] Make `ndarray.pyi` generation errors use `ImportWarning`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,8 @@
 - [#42](https://github.com/p2p-ld/numpydantic/issues/42), [#43](https://github.com/p2p-ld/numpydantic/pulls/43) - 
   Use an `ImportWarning` rather than a `UserWarning` when a stubfile can't be generated and saved
   (e.g. due to a read-only filesystem or permissions error) so it only shows in CI and not at runtime.
+- [#44](https://github.com/p2p-ld/numpydantic/issues/44) - Zarr 3.0 changed a ton about how zarr works,
+  so until we can adapt the interface, put an upper bound of `<3.0.0` for zarr
 
 #### 1.6.6 - 24-12-13
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,14 @@
 
 ### 1.6.*
 
+#### 1.6.7 - 25-01-23
+
+**UX**
+
+- [#42](https://github.com/p2p-ld/numpydantic/issues/42), [#43](https://github.com/p2p-ld/numpydantic/pulls/43) - 
+  Use an `ImportWarning` rather than a `UserWarning` when a stubfile can't be generated and saved
+  (e.g. due to a read-only filesystem or permissions error) so it only shows in CI and not at runtime.
+
 #### 1.6.6 - 24-12-13
 
 **Bugfix**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ video = [
     "opencv-python>=4.9.0.80",
 ]
 zarr = [
-    "zarr>=2.17.2",
+    "zarr>=2.17.2,<3.0.0",
 ]
 arrays = [
     "numpydantic[dask,hdf5,zarr,video]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "numpydantic"
-version = "1.6.6"
+version = "1.6.7"
 description = "Type and shape validation and serialization for arbitrary array types in pydantic models"
 authors = [
     {name = "sneakers-the-rat", email = "sneakers-the-rat@protonmail.com"},

--- a/src/numpydantic/meta.py
+++ b/src/numpydantic/meta.py
@@ -63,4 +63,8 @@ def update_ndarray_stub() -> None:
         with open(pyi_file, "w") as pyi:
             pyi.write(stub_string)
     except Exception as e:  # pragma: no cover
-        warn(f"ndarray.pyi stub file could not be generated: {e}", stacklevel=1)
+        warn(
+            f"ndarray.pyi stub file could not be generated: {e}",
+            category=ImportWarning,
+            stacklevel=1,
+        )


### PR DESCRIPTION
Fix: https://github.com/p2p-ld/numpydantic/issues/42

type stub generation errors don't affect the functionality of the package, which is why this is just a warning not an exception, but that warning can be annoying in contexts where one isn't expected to be able to write files (e.g. system packages, within a docker container).

switching to an `ImportWarning` which is hidden by default, but still shows up in CI in case there are people working on downstream plugins (which is why this is autogenerated rather than versioned)