### PR TITLE
Handle `np.datetime64` and other numpy dtypes with odd subclasses/constructors

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,15 @@
 
 ### 1.6.*
 
+#### 1.6.8 - 25-03-10
+
+**Bugfix**
+
+- [#46](https://github.com/p2p-ld/numpydantic/issues/46), [#47](https://github.com/p2p-ld/numpydantic/pull/47) - 
+  Correctly handle `np.datetime64` types. Typically `datetime.datetime` would be used to be generic across interfaces,
+  but special types like `np.datetime64` were incorrectly rejected because they have a special type function/class
+  relationship similar to `np.str_`. Make dtype checking also check the `dtype.type` attribute, if present.
+
 #### 1.6.7 - 25-01-23
 
 **UX**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "numpydantic"
-version = "1.6.7"
+version = "1.6.8"
 description = "Type and shape validation and serialization for arbitrary array types in pydantic models"
 authors = [
     {name = "sneakers-the-rat", email = "sneakers-the-rat@protonmail.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ docs = [
 dev = [
     "numpydantic[tests,docs]",
     "sphinx-autobuild>=2021.3.14",
-    "black<25.0.0,>=24.1.1",
+    "black>=24.1.1",
     "ruff<1.0.0,>=0.2.0"
 ]
 
@@ -98,8 +98,14 @@ distribution = true
 includes = []
 
 [tool.pdm.scripts]
-lint = "ruff check"
-format = {shell = "ruff check --fix ; black ."}
+lint.composite = [
+    "ruff check",
+    "black . --diff",
+]
+format.composite = [
+    "black .",
+    "ruff check --fix",
+]
 test = "pytest"
 
 [build-system]

--- a/src/numpydantic/dtype.py
+++ b/src/numpydantic/dtype.py
@@ -13,7 +13,7 @@ Some types like `Integer` are compound types - tuples of multiple dtypes.
 Check these using ``in`` rather than ``==``. This interface will develop in future
 versions to allow a single dtype check.
 
-For internal helper functions for validating dtype, 
+For internal helper functions for validating dtype,
 see :mod:`numpydantic.validation.dtype`
 """
 

--- a/src/numpydantic/interface/hdf5.py
+++ b/src/numpydantic/interface/hdf5.py
@@ -5,28 +5,28 @@ Interfaces for HDF5 Datasets
 
     HDF5 arrays are accessed through a proxy class :class:`.H5Proxy` .
     Getting/setting values should work as normal, **except** that setting
-    values on nested views is impossible - 
-    
+    values on nested views is impossible -
+
     Specifically this doesn't work:
-    
+
     .. code-block:: python
-    
+
         my_model.array[0][0] = 1
-    
+
     But this does work:
-    
+
     .. code-block:: python
-    
+
         my_model.array[0,0] = 1
-        
+
     To have direct access to the hdf5 dataset, use the
     :meth:`.H5Proxy.open` method.
-    
-Datetimes 
+
+Datetimes
 ---------
 
 Datetimes are supported as a dtype annotation, but currently they must be stored
-as ``S32`` isoformatted byte strings (timezones optional) like:    
+as ``S32`` isoformatted byte strings (timezones optional) like:
 
 .. code-block:: python
 
@@ -36,7 +36,7 @@ as ``S32`` isoformatted byte strings (timezones optional) like:
     data = np.array([datetime.now().isoformat().encode('utf-8')], dtype="S32")
     h5f = h5py.File('test.hdf5', 'w')
     h5f.create_dataset('data', data=data)
-    
+
 """
 
 import sys

--- a/src/numpydantic/interface/zarr.py
+++ b/src/numpydantic/interface/zarr.py
@@ -96,7 +96,7 @@ class ZarrInterface(Interface):
 
     @staticmethod
     def _get_array(
-        array: Union[ZarrArray, str, dict, ZarrJsonDict, Path, ZarrArrayPath, Sequence]
+        array: Union[ZarrArray, str, dict, ZarrJsonDict, Path, ZarrArrayPath, Sequence],
     ) -> ZarrArray:
         if isinstance(array, ZarrArray):
             return array

--- a/src/numpydantic/validation/dtype.py
+++ b/src/numpydantic/validation/dtype.py
@@ -47,8 +47,9 @@ def validate_dtype(dtype: Any, target: DtypeType) -> bool:
         try:
             valid = issubclass(dtype, target)
         except TypeError:
-            # expected, if dtype or target is not a class
-            valid = dtype == target
+            # error expected if dtype or target is not a class
+            # main type check - directly test dtype identity
+            valid = dtype == target or getattr(dtype, "type", None) == target
 
     return valid
 

--- a/src/numpydantic/vendor/nptyping/structure_expression.py
+++ b/src/numpydantic/vendor/nptyping/structure_expression.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
 
 
 def validate_structure_expression(
-    structure_expression: Union[StructureExpression, Any]
+    structure_expression: Union[StructureExpression, Any],
 ) -> None:
     """
     Validate the given structure_expression and raise an InvalidStructureError

--- a/tests/test_interface/test_numpy.py
+++ b/tests/test_interface/test_numpy.py
@@ -1,6 +1,10 @@
+from datetime import datetime
+
 import numpy as np
 import pytest
+from pydantic import BaseModel
 
+from numpydantic import NDArray, Shape
 from numpydantic.testing.cases import NumpyCase
 
 pytestmark = pytest.mark.numpy
@@ -16,6 +20,29 @@ def test_numpy_shape(shape_cases):
 def test_numpy_dtype(dtype_cases):
     dtype_cases.interface = NumpyCase
     dtype_cases.validate_case()
+
+
+@pytest.mark.dtype
+def test_numpy_datetime64():
+    """
+    Special testing for datetime64, since it's a numpy-specific thing,
+    and requires special handling in the other interfaces.
+
+    Typically, we expect that generic type annotation to be a `datetime.datetime`,
+    but it should also be possible to use a numpy.datetime64 type when doing
+    numpy validation.
+
+    So this test is just the simplest regression test to make sure we can use datetime64
+    """
+    arr = np.array([np.datetime64(datetime.now())], dtype=np.datetime64)
+
+    annotation = NDArray[Shape["*"], np.datetime64]
+    _ = annotation(arr)
+
+    class MyModel(BaseModel):
+        array: annotation
+
+    _ = MyModel(array=arr)
 
 
 def test_numpy_coercion(model_blank):


### PR DESCRIPTION
Fix: https://github.com/p2p-ld/numpydantic/issues/46

`np.datetime64` isn't a dtype class like other dtypes, it produces a different type:

```python
>>> arr = np.array([np.datetime64(datetime.now())], dtype=np.datetime64)
>>> arr.dtype
dtype('<M8[us]')
>>> type(arr.dtype)
numpy.dtypes.DateTime64DType
```

But the `type` attribute is unambiguous:

```python
>>> arr.dtype.type
numpy.datetime64
```

This is similar to numpy string dtypes.

Fix is simple and generic - just check the `type` attribute if it's present.

opening first with failing test, then with fix