### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix some typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ pip install 'numpydantic[video]'
 # zarr
 pip install 'numpydantic[zarr]'
 # all array formats
-pip intsall 'numpydantic[array]'
+pip install 'numpydantic[array]'
 ```
 
 ## Usage

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -398,7 +398,7 @@ See the docstrings for descriptions of each class
 
 **Bugfix**
 - [`#17`](https://github.com/p2p-ld/numpydantic/issues/17) - Arrays are re-validated as lists, rather than arrays
-- Some proxy classes would fail to be serialized becauase they lacked an `__array__` method.
+- Some proxy classes would fail to be serialized because they lacked an `__array__` method.
   `__array__` methods have been added, and tests for coercing to an array to prevent regression.
 - Some proxy classes lacked a `__name__` attribute, which caused failures to serialize
   when the `__getattr__` methods attempted to pass it through. These have been added where needed.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,7 +29,7 @@
 - [`#58`](https://github.com/p2p-ld/numpydantic/pull/58) -
   The `NDArray` class is now a Protocol at runtime, 
   and now statically typechecks as a numpy array for non-mypy static type checkers,
-  greatly improving compabitility.
+  greatly improving compatibility.
 
 **Removed**
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -62,7 +62,7 @@ There are three major parts to a validation case:
 - **Array specification:** {attr}`~.ValidationCase.dtype` and {attr}`~.ValidationCase.shape`
   specify that array that will be generated to test against the annotation
 - **Interface specification:** An {class}`.InterfaceCase` that refers to
-  an {class}`.Interface`, and provides array generation and other auxilary logic.
+  an {class}`.Interface`, and provides array generation and other auxiliary logic.
 
 Typically, one specifies a dtype along with an annotation dtype or
 a shape along with an annotation shape (or implicitly against the defaults for either),
@@ -190,7 +190,7 @@ combinations of interfaces and test parameterizations that should be skipped.
 
 ## Making Fixtures
 
-Pytest fixtures are a useful way to re-use validation case products.
+Pytest fixtures are a useful way to reuse validation case products.
 To keep things tidy, you may want to use marks and ids when creating them
 so that you can run tests against specific interfaces or conditions
 with the `pytest -m mark` system.

--- a/docs/design.md
+++ b/docs/design.md
@@ -2,7 +2,7 @@
 
 ## Why do this?
 
-We want to bring the tidyness of modeling data with pydantic to the universe of
+We want to bring the tidiness of modeling data with pydantic to the universe of
 software that uses arrays - particularly formats and packages that need to be very 
 particular about what *kind* of arrays they are able to handle or match a specific schema.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,7 +157,7 @@ pip install 'numpydantic[video]'
 # zarr
 pip install 'numpydantic[zarr]'
 # all array formats
-pip intsall 'numpydantic[array]'
+pip install 'numpydantic[array]'
 ```
 
 ## Usage
@@ -275,7 +275,7 @@ object and leave the file open between calls:
 
 ```python
 >>> dataset = h5f_image.array.open()
->>> # do some stuff that requires the datset to be held open
+>>> # do some stuff that requires the dataset to be held open
 >>> h5f_image.array.close()
 ```
 

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -276,7 +276,7 @@ A reference listing of all the things that can be passed to
 
 ### `mark_interface`
 
-Nest an additional layer of metadata for unambigous serialization that
+Nest an additional layer of metadata for unambiguous serialization that
 can be absolutely resolved across numpydantic versions 
 (for now for downstream metadata purposes only, 
 automatically resolving to a numpydantic version is not yet possible.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,3 +246,9 @@ init_typed = true
 omit = [
     "src/numpydantic/vendor/*"
 ]
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,vendor,*.lock,*.css'
+check-hidden = true
+# ignore-regex = ''
+ignore-words-list = 'afile'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,7 +248,9 @@ omit = [
 ]
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git*,vendor,*.lock,*.css'
+# *.bib: BibTeX citation data — author names and verbatim quoted
+# abstracts must remain unmodified
+skip = '.git*,vendor,*.lock,*.css,*.bib'
 check-hidden = true
 # ignore-regex = ''
 ignore-words-list = 'afile'

--- a/src/numpydantic/dtype.pyi
+++ b/src/numpydantic/dtype.pyi
@@ -2,7 +2,7 @@
 
 The compound dtype names (``Integer``, ``Float``, ``Complex``, ``Number``,
 ``Int``, ``SignedInteger``, ``UnsignedInteger``, ``Floating``) are tuples of
-numpy generic types at runtime. We re-declare them here as union ``TypeAlias``
+numpy generic types at runtime. We redeclare them here as union ``TypeAlias``
 values so they can be used as the dtype argument of
 :class:`numpydantic.NDArray`.
 """

--- a/src/numpydantic/interface/video.py
+++ b/src/numpydantic/interface/video.py
@@ -70,7 +70,7 @@ class VideoProxy(Proxy):
             if self.path is None:  # pragma: no cover
                 raise RuntimeError(
                     "Instantiated with a VideoCapture object that has been closed, "
-                    "and it cant be reopened since source path cant be gotten "
+                    "and it can't be reopened since source path can't be gotten "
                     "from VideoCapture objects"
                 )
             if not self.path.exists():
@@ -188,7 +188,7 @@ class VideoProxy(Proxy):
 
             elif isinstance(item[0], slice):
                 frames = []
-                # make a new slice since range cant take Nones, filling in missing vals
+                # make a new slice since range can't take Nones, filling in missing vals
                 fslice = self._complete_slice(item[0])
 
                 for i in range(fslice.start, fslice.stop, fslice.step):

--- a/src/numpydantic/validation/shape.py
+++ b/src/numpydantic/validation/shape.py
@@ -91,7 +91,7 @@ class Shape(NPTypingType, ABC, Generic[Unpack[_TV]], metaclass=ShapeMeta):
 
     >>> Shape['2, 2'] == Shape('2, 2')
 
-    And its arguments can be pased as ``args``, with ints and strings as appropriate
+    And its arguments can be passed as ``args``, with ints and strings as appropriate
 
     >>> Shape(2, 2, "...") == Shape("2, 2, ...")
 

--- a/tests/test_interface/test_interface_base.py
+++ b/tests/test_interface/test_interface_base.py
@@ -120,7 +120,7 @@ def test_interface_match_fast(interfaces):
     """
     Interface.interfaces()[0].checked = False
     Interface.interfaces()[1].checked = False
-    # this doesnt' raise an error
+    # this doesn't raise an error
     matched = Interface.match([1, 2, 3], fast=True)
     assert matched == Interface.interfaces()[0]
     assert Interface.interfaces()[0].checked
@@ -189,7 +189,7 @@ def test_jsondict_is_valid():
     A JsonDict should return a bool true/false if it is valid or not,
     and raise an error when requested
     """
-    invalid = {"doesnt": "have", "the": "props"}
+    invalid = {"doesnt": "have", "the": "props"}  # codespell:ignore
     valid = {"type": "my_json_dict", "field": "a_field", "number": 1}
     assert MyJsonDict.is_valid(valid)
     assert not MyJsonDict.is_valid(invalid)

--- a/tests/test_interface/test_numpy.py
+++ b/tests/test_interface/test_numpy.py
@@ -81,7 +81,7 @@ def test_numpy_coercion(model_blank):
 @pytest.mark.serialization
 def test_numpy_empty_string():
     """
-    Empty strings are coerced to arrays and serialzied as such.
+    Empty strings are coerced to arrays and serialized as such.
 
     Mildly redundant with test_serialize_scalars_as_arrays below,
     but a specific regression test for issue #52

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -167,4 +167,4 @@ def test_mypy_generated(
     if case.passes:
         assert returncode == 0, "Should have passed mypy!\n" + msg
     else:
-        assert returncode != 0, "Should not have pased mypy!\n" + msg
+        assert returncode != 0, "Should not have passed mypy!\n" + msg

--- a/tests/test_testing_helpers.py
+++ b/tests/test_testing_helpers.py
@@ -49,7 +49,7 @@ def test_make_array(interface, tmp_output_dir_func):
     """
     An interface case can generate an array from params or a given array
 
-    Not testing correctness here, that's what hte rest of the testing does.
+    Not testing correctness here, that's what the rest of the testing does.
     """
     arr = np.zeros((10, 10, 2, 3), dtype=np.uint8)
     arr = interface.make_array(array=arr, dtype=np.uint8, path=tmp_output_dir_func)


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.