### PR TITLE
Basic mypy compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ ndarray.pyi
 prof/
 __tmp__
 docs/jupyter_execute
+*.bak

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -6,6 +6,14 @@ General form:
 field: NDArray[Shape["{shape_expression}"], dtype]
 ```
 
+For better compatibility with static type checkers,
+rather than `Shape` with a string literal, you can use {class}`typing.Literal`
+anywhere you can use `Shape`.
+
+```python
+field: NDArray[Literal["{shape_expression"], dtype]
+```
+
 ## Dtype
 
 Dtype checking is for the most part as simple as an `isinstance` check - 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "arrays", "dask", "dev", "docs", "hdf5", "tests", "video", "zarr"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:60014c0ab34a632ad5b0a8e76bdf32d4205b297e089da4f668271da19799c46d"
+content_hash = "sha256:82899e916213f01be94744dd608acae5587d1ece88cab09009255fa710d67a00"
 
 [[metadata.targets]]
 requires_python = "~=3.9"
@@ -1135,11 +1135,64 @@ files = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.17.1"
+requires_python = ">=3.9"
+summary = "Optional static typing for Python"
+groups = ["dev", "tests"]
+dependencies = [
+    "mypy-extensions>=1.0.0",
+    "pathspec>=0.9.0",
+    "tomli>=1.1.0; python_version < \"3.11\"",
+    "typing-extensions>=4.6.0",
+]
+files = [
+    {file = "mypy-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3fbe6d5555bf608c47203baa3e72dbc6ec9965b3d7c318aa9a4ca76f465bd972"},
+    {file = "mypy-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:80ef5c058b7bce08c83cac668158cb7edea692e458d21098c7d3bce35a5d43e7"},
+    {file = "mypy-1.17.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4a580f8a70c69e4a75587bd925d298434057fe2a428faaf927ffe6e4b9a98df"},
+    {file = "mypy-1.17.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd86bb649299f09d987a2eebb4d52d10603224500792e1bee18303bbcc1ce390"},
+    {file = "mypy-1.17.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a76906f26bd8d51ea9504966a9c25419f2e668f012e0bdf3da4ea1526c534d94"},
+    {file = "mypy-1.17.1-cp310-cp310-win_amd64.whl", hash = "sha256:e79311f2d904ccb59787477b7bd5d26f3347789c06fcd7656fa500875290264b"},
+    {file = "mypy-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ad37544be07c5d7fba814eb370e006df58fed8ad1ef33ed1649cb1889ba6ff58"},
+    {file = "mypy-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:064e2ff508e5464b4bd807a7c1625bc5047c5022b85c70f030680e18f37273a5"},
+    {file = "mypy-1.17.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70401bbabd2fa1aa7c43bb358f54037baf0586f41e83b0ae67dd0534fc64edfd"},
+    {file = "mypy-1.17.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e92bdc656b7757c438660f775f872a669b8ff374edc4d18277d86b63edba6b8b"},
+    {file = "mypy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c1fdf4abb29ed1cb091cf432979e162c208a5ac676ce35010373ff29247bcad5"},
+    {file = "mypy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:ff2933428516ab63f961644bc49bc4cbe42bbffb2cd3b71cc7277c07d16b1a8b"},
+    {file = "mypy-1.17.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:69e83ea6553a3ba79c08c6e15dbd9bfa912ec1e493bf75489ef93beb65209aeb"},
+    {file = "mypy-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1b16708a66d38abb1e6b5702f5c2c87e133289da36f6a1d15f6a5221085c6403"},
+    {file = "mypy-1.17.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:89e972c0035e9e05823907ad5398c5a73b9f47a002b22359b177d40bdaee7056"},
+    {file = "mypy-1.17.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03b6d0ed2b188e35ee6d5c36b5580cffd6da23319991c49ab5556c023ccf1341"},
+    {file = "mypy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c837b896b37cd103570d776bda106eabb8737aa6dd4f248451aecf53030cdbeb"},
+    {file = "mypy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:665afab0963a4b39dff7c1fa563cc8b11ecff7910206db4b2e64dd1ba25aed19"},
+    {file = "mypy-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:93378d3203a5c0800c6b6d850ad2f19f7a3cdf1a3701d3416dbf128805c6a6a7"},
+    {file = "mypy-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:15d54056f7fe7a826d897789f53dd6377ec2ea8ba6f776dc83c2902b899fee81"},
+    {file = "mypy-1.17.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:209a58fed9987eccc20f2ca94afe7257a8f46eb5df1fb69958650973230f91e6"},
+    {file = "mypy-1.17.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:099b9a5da47de9e2cb5165e581f158e854d9e19d2e96b6698c0d64de911dd849"},
+    {file = "mypy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa6ffadfbe6994d724c5a1bb6123a7d27dd68fc9c059561cd33b664a79578e14"},
+    {file = "mypy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:9a2b7d9180aed171f033c9f2fc6c204c1245cf60b0cb61cf2e7acc24eea78e0a"},
+    {file = "mypy-1.17.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:15a83369400454c41ed3a118e0cc58bd8123921a602f385cb6d6ea5df050c733"},
+    {file = "mypy-1.17.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:55b918670f692fc9fba55c3298d8a3beae295c5cded0a55dccdc5bbead814acd"},
+    {file = "mypy-1.17.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:62761474061feef6f720149d7ba876122007ddc64adff5ba6f374fda35a018a0"},
+    {file = "mypy-1.17.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c49562d3d908fd49ed0938e5423daed8d407774a479b595b143a3d7f87cdae6a"},
+    {file = "mypy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:397fba5d7616a5bc60b45c7ed204717eaddc38f826e3645402c426057ead9a91"},
+    {file = "mypy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:9d6b20b97d373f41617bd0708fd46aa656059af57f2ef72aa8c7d6a2b73b74ed"},
+    {file = "mypy-1.17.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5d1092694f166a7e56c805caaf794e0585cabdbf1df36911c414e4e9abb62ae9"},
+    {file = "mypy-1.17.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:79d44f9bfb004941ebb0abe8eff6504223a9c1ac51ef967d1263c6572bbebc99"},
+    {file = "mypy-1.17.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b01586eed696ec905e61bd2568f48740f7ac4a45b3a468e6423a03d3788a51a8"},
+    {file = "mypy-1.17.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43808d9476c36b927fbcd0b0255ce75efe1b68a080154a38ae68a7e62de8f0f8"},
+    {file = "mypy-1.17.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:feb8cc32d319edd5859da2cc084493b3e2ce5e49a946377663cc90f6c15fb259"},
+    {file = "mypy-1.17.1-cp39-cp39-win_amd64.whl", hash = "sha256:d7598cf74c3e16539d4e2f0b8d8c318e00041553d83d4861f87c7a72e95ac24d"},
+    {file = "mypy-1.17.1-py3-none-any.whl", hash = "sha256:a9f52c0351c21fe24c21d8c0eb1f62967b262d6729393397b6f443c3b773c3b9"},
+    {file = "mypy-1.17.1.tar.gz", hash = "sha256:25e01ec741ab5bb3eec8ba9cdb0f769230368a22c959c4937360efb89b7e9f01"},
+]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 requires_python = ">=3.8"
 summary = "Type system extensions for programs checked with the mypy type checker."
-groups = ["dev"]
+groups = ["dev", "tests"]
 files = [
     {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
     {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
@@ -1388,7 +1441,7 @@ name = "pathspec"
 version = "0.12.1"
 requires_python = ">=3.8"
 summary = "Utility library for gitignore style pattern matching of file paths."
-groups = ["dev"]
+groups = ["dev", "tests"]
 files = [
     {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
     {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ tests = [
     "coverage>=6.1.1",
     "pytest-cov<5.0.0,>=4.1.0",
     "coveralls<4.0.0,>=3.3.1",
+    "mypy>=1.17.1",
 ]
 docs = [
     "numpydantic[arrays]",

--- a/src/numpydantic/meta.py
+++ b/src/numpydantic/meta.py
@@ -8,6 +8,14 @@ from warnings import warn
 from numpydantic.interface import Interface
 
 _BUILTIN_IMPORTS = ("import typing", "import pathlib")
+_PREAMBLE = """
+# Add mypy-style generic params to a static type
+# https://mypy.readthedocs.io/en/stable/generics.html#generic-type-aliases
+TShape = typing.TypeVar('TShape')
+TDtype = typing.TypeVar('TDtype')
+
+"""
+_STATIC_TYPES = ("TShape", "TDtype")
 
 
 def generate_ndarray_stub() -> str:
@@ -16,7 +24,7 @@ def generate_ndarray_stub() -> str:
     """
 
     import_strings = []
-    type_names = []
+    type_names = [*_STATIC_TYPES]
     for arr in Interface.input_types():
         if arr.__module__ == "builtins":
             continue
@@ -46,7 +54,7 @@ def generate_ndarray_stub() -> str:
     class_union = " | ".join(type_names)
     ndarray_type = "NDArray = " + class_union
 
-    stub_string = "\n".join([import_string, ndarray_type])
+    stub_string = "\n".join([import_string, _PREAMBLE, ndarray_type])
     return stub_string
 
 

--- a/src/numpydantic/ndarray.py
+++ b/src/numpydantic/ndarray.py
@@ -162,9 +162,15 @@ class NDArray(NPTypingType, metaclass=NDArrayMeta):
     Constrained array type allowing npytyping syntax for dtype and shape validation
     and serialization.
 
-    This class is not intended to be instantiated or used for type checking, it
-    implements the ``__get_pydantic_core_schema__` method to invoke
+    This class is not intended to be instantiable, and support for static type
+    checking is limited,
+    it implements the ``__get_pydantic_core_schema__`` method to invoke
     the relevant :ref:`interface <Interfaces>` for validation and serialization.
+
+    It is callable, however, which validates and attempts to coerce input to a
+    supported array type.
+    There is no such thing as an "NDArray instance," but one can think of it
+    as a validating passthrough callable.
 
     References:
         - https://docs.pydantic.dev/latest/usage/types/custom/#handling-third-party-types

--- a/src/numpydantic/validation/shape.py
+++ b/src/numpydantic/validation/shape.py
@@ -27,10 +27,10 @@ import re
 import string
 from abc import ABC
 from functools import lru_cache
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, Generic, List, Literal, TypeVar, Union
 
 from numpydantic.vendor.nptyping.base_meta_classes import ContainerMeta
-from numpydantic.vendor.nptyping.error import InvalidShapeError, NPTypingError
+from numpydantic.vendor.nptyping.error import InvalidShapeError
 from numpydantic.vendor.nptyping.nptyping_type import NPTypingType
 from numpydantic.vendor.nptyping.shape_expression import (
     get_dimensions,
@@ -38,6 +38,8 @@ from numpydantic.vendor.nptyping.shape_expression import (
     remove_labels,
 )
 from numpydantic.vendor.nptyping.typing_ import ShapeExpression, ShapeTuple
+
+T = TypeVar("T", bound=Literal[str])
 
 
 class ShapeMeta(ContainerMeta, implementation="Shape"):
@@ -58,16 +60,8 @@ class ShapeMeta(ContainerMeta, implementation="Shape"):
         dim_string_without_labels = remove_labels(dim_strings)
         return {"prepared_args": dim_string_without_labels}
 
-    def __setattr__(cls, key: str, value: Any) -> None:  # pragma: no cover
-        """just for documentation generation - allow __annotations__"""
 
-        if key not in ("_abc_impl", "__abstractmethods__", "__annotations__"):
-            raise NPTypingError(f"Cannot set values to nptyping.{cls.__name__}.")
-        else:
-            object.__setattr__(cls, key, value)
-
-
-class Shape(NPTypingType, ABC, metaclass=ShapeMeta):
+class Shape(NPTypingType, ABC, Generic[T], metaclass=ShapeMeta):
     """
     A container for shape expressions that describe the shape of an multi
     dimensional array.

--- a/src/numpydantic/vendor/nptyping/base_meta_classes.py
+++ b/src/numpydantic/vendor/nptyping/base_meta_classes.py
@@ -51,16 +51,6 @@ class InconstructableMeta(ABCMeta):
         )
 
 
-class ImmutableMeta(ABCMeta):
-    """
-    Makes it impossible to changes values on a class.
-    """
-
-    def __setattr__(cls, key: str, value: Any) -> None:
-        if key not in ("_abc_impl", "__abstractmethods__"):
-            raise NPTypingError(f"Cannot set values to nptyping.{cls.__name__}.")
-
-
 class FinalMeta(ABCMeta):
     """
     Makes it impossible for classes to inherit from some class.
@@ -190,7 +180,6 @@ class ComparableByArgsMeta(ABCMeta):
 
 class ContainerMeta(
     InconstructableMeta,
-    ImmutableMeta,
     FinalMeta,
     MaybeCheckableMeta,
     PrintableMeta,

--- a/src/numpydantic/vendor/nptyping/ndarray.py
+++ b/src/numpydantic/vendor/nptyping/ndarray.py
@@ -30,7 +30,6 @@ import numpy as np
 
 from numpydantic.vendor.nptyping.base_meta_classes import (
     FinalMeta,
-    ImmutableMeta,
     MaybeCheckableMeta,
     PrintableMeta,
     SubscriptableMeta,
@@ -53,7 +52,6 @@ from numpydantic.vendor.nptyping.typing_ import (
 
 class NDArrayMeta(
     SubscriptableMeta,
-    ImmutableMeta,
     FinalMeta,
     MaybeCheckableMeta,
     PrintableMeta,

--- a/src/numpydantic/vendor/nptyping/pandas_/dataframe.py
+++ b/src/numpydantic/vendor/nptyping/pandas_/dataframe.py
@@ -31,7 +31,6 @@ import numpy as np
 from numpydantic.vendor.nptyping import InvalidArgumentsError
 from numpydantic.vendor.nptyping.base_meta_classes import (
     FinalMeta,
-    ImmutableMeta,
     InconstructableMeta,
     MaybeCheckableMeta,
     PrintableMeta,
@@ -52,7 +51,6 @@ except ImportError:  # pragma: no cover
 class DataFrameMeta(
     SubscriptableMeta,
     InconstructableMeta,
-    ImmutableMeta,
     FinalMeta,
     MaybeCheckableMeta,
     PrintableMeta,

--- a/tests/data/mypy/numpy_ndarray.py
+++ b/tests/data/mypy/numpy_ndarray.py
@@ -1,0 +1,16 @@
+from typing import Any
+from typing import Literal as L
+
+import numpy as np
+
+from numpydantic import NDArray, Shape
+
+x: NDArray[Shape[L["1"]], Any] = np.empty((1,))
+
+
+def a_func(array: np.typing.NDArray) -> None:
+    pass
+
+
+if isinstance(x, np.ndarray):
+    a_func(x)

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -31,4 +31,4 @@ def refresh_stubs():
 def test_mypy(test_file: Path):
     """The mypy examples should pass static type checking"""
     res = mypy.api.run([str(test_file)])
-    breakpoint()
+    assert res == ("Success: no issues found in 1 source file\n", "", 0)

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import mypy.api
+import pytest
+
+from numpydantic import ndarray
+from numpydantic.meta import update_ndarray_stub
+
+MYPY_DIR = Path(__file__).parent / "data" / "mypy"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def refresh_stubs():
+    """Ensure no stale stubs"""
+    # ensure all interfaces are imported
+    from numpydantic import interface  # noqa: F401
+
+    stub_file = Path(ndarray.__file__).with_suffix(".pyi")
+    backup_file = stub_file.with_suffix(".pyi.bak")
+    if stub_file.exists():
+        stub_file.rename(backup_file)
+
+    update_ndarray_stub()
+    yield
+    if backup_file.exists():
+        stub_file.unlink(missing_ok=True)
+        backup_file.rename(stub_file)
+
+
+@pytest.mark.parametrize("test_file", MYPY_DIR.glob("*.py"))
+def test_mypy(test_file: Path):
+    """The mypy examples should pass static type checking"""
+    res = mypy.api.run([str(test_file)])
+    breakpoint()

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -1,10 +1,11 @@
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import pytest
 from pydantic import BaseModel, ValidationError
 
 from numpydantic import NDArray, Shape
+from numpydantic.exceptions import ShapeError
 
 pytestmark = pytest.mark.shape
 
@@ -77,3 +78,20 @@ def test_range_shape_schema():
     assert "maxItems" not in schema["properties"]["array_range_min"]
     assert schema["properties"]["array_range_max"]["maxItems"] == 4
     assert "minItems" not in schema["properties"]["array_range_max"]
+
+
+def test_shape_literal():
+    """
+    We can use `Literal` instead of the `Shape` object.
+
+    We do not test for correctness of validation here,
+    assuming that it handles `Literal` strings exactly the same
+    way that it does `Shape[]` strings.
+    """
+    array_type = NDArray[Literal["1, 2, ..."], Any]
+
+    # validates
+    _ = array_type(np.zeros((1, 2, 3)))
+    # fails to validate
+    with pytest.raises(ShapeError):
+        _ = array_type(np.zeros((4, 5)))


### PR DESCRIPTION
Related to: https://github.com/p2p-ld/numpydantic/issues/32

While writing this, realized there was a very easy path to get basic mypy compatibility, even though it doesn't get us to where we want to be.

We should at least be able to write annotations without needing to ignore major linter rules and failing mypy altogether.

Following https://github.com/p2p-ld/numpydantic/pull/55 mypy will actually use the type stub,
and previously we have implemented support for `Literal` instead of `Shape`, though this wasn't documented?

The only thing remaining was that mypy didn't detect that `NDArray` and `Shape` should accept generic params, added them to the type stub and to the shape class. the `Final` class creation and the `Immutable` metaclasses interfered with being able to set the generic dunder attrs, and they are sorta silly anyway, don't really accomplish anything, and will be deprecated soon, so they were removed.

Added the most basic mypy test and a tiny bit of documentation on using literals