### PR TITLE
make annotated schema class, allow shape to accept tuples and be call…

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,9 +1,9 @@
 # numpydantic
 
-Top-level API contents
+Top-level API contents 
 
 ```{eval-rst}
 .. automodule:: numpydantic
     :members:
     :imported-members:
-``` 
+```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,10 +1,36 @@
 # Changelog
 
-## Upcoming
-
-- Drop support for python 3.9, add (testing) support for 3.14
-
 ## 1.*
+
+### 1.8.*
+
+#### 1.8.0 - 26-02-26
+
+**Version Support**
+
+- [#63](https://github.com/p2p-ld/numpydantic/pull/63) -
+  Drop support for python 3.9, add (testing) support for 3.14
+
+**Added**
+
+- [#41](https://github.com/p2p-ld/numpydantic/issues/41)
+  [#62](https://github.com/p2p-ld/numpydantic/issues/62)
+  [#64](https://github.com/p2p-ld/numpydantic/pull/64) -
+  Add a {func}`.NDArraySchema` Annotated style specification to support static type checkers:
+
+```python
+from numpydantic import NDArraySchema
+
+class MyModel(BaseModel):
+  array: Annotated[np.ndarray, NDArraySchema((1, 2, 3), np.uint8)]
+```
+
+- Allow shape to be used as a callable rather than a `[]` generic
+- Allow shape to accept shape arguments as `*args` rather than a single string
+
+**Testing**
+
+- Added pyright testing
 
 ### 1.7.*
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,23 @@ model = MyModel(array=('data.zarr', '/nested/dataset'))
 model = MyModel(array="data.mp4")
 ```
 
+Or, if you don't care about compatibility with multiple array backends and want explicit type checking,
+use numpydantic as an annotated type - 
+shapes and dtypes will still be validated by pydantic,
+but the rest of your code will just see the field as a normal array.
+
+```python
+from typing import Annotated as A
+from numpydantic import NDArraySchema
+
+class MyAnnotatedModel(BaseModel):
+    # shapes can also be specified in a functional form with (),
+    # and if you don't need labels, as separate arguments
+    array: A[np.ndarray, NDArraySchema(Shape(3, 4, 5, "..."), int)]
+    # or, throw out the shape object altogether!
+    array: A[np.ndarray, NDArraySchema((3, 4, 5, "..."), int)]
+```
+
 `numpydantic` supports pydantic but none of its behavior is dependent on it!
 Use the `NDArray` type annotation like a regular type outside
 of pydantic -- eg. to validate an array anywhere, use `isinstance`:

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -29,7 +29,7 @@ Shape can also be invoked as a callable
 field: NDArray[Shape(1, 2, 3), dtype]
 ```
 
-If you don't need 
+If you don't need compatibility with multiple array backends,
 Within pydantic models, you can use the annotated schema form with :func:`.NDArraySchema`
 
 ```python

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -6,6 +6,8 @@ General form:
 field: NDArray[Shape["{shape_expression}"], dtype]
 ```
 
+## Type checker compatibility
+
 For better compatibility with static type checkers,
 rather than `Shape` with a string literal, you can use {class}`typing.Literal`
 anywhere you can use `Shape`.
@@ -13,6 +15,32 @@ anywhere you can use `Shape`.
 ```python
 field: NDArray[Literal["{shape_expression"], dtype]
 ```
+
+Or, if you don't need axis labels, you can pass the parts of a shape expression as separate args
+
+```python
+field: NDArray[Shape[1, 2, 3], dtype]
+```
+
+And if your type checker complains about using a string literal as a generic,
+Shape can also be invoked as a callable
+
+```python
+field: NDArray[Shape(1, 2, 3), dtype]
+```
+
+If you don't need 
+Within pydantic models, you can use the annotated schema form with :func:`.NDArraySchema`
+
+```python
+from numpydantic import NDArraySchema
+class MyModel(BaseModel):
+    field = Annotated[np.ndarray, NDArraySchema(Shape("{shape_expression}"), dtype)]
+```
+
+:func:`.NDArraySchema` also validates that the given array is of the specified type,
+rather than any array backend that matches the dtype and shape.
+
 
 ## Dtype
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "arrays", "dask", "dev", "docs", "hdf5", "tests", "video", "zarr"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:12e24f4d02340919a8bcda8bd5941389f4344b049ad034545761cef9cb4abb29"
+content_hash = "sha256:1fb2a31ef9c7ce849e3fe404a1b760a165dfd4b0dc6d16070077717734c30c0a"
 
 [[metadata.targets]]
 requires_python = "~=3.10"
@@ -1419,6 +1419,17 @@ files = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+summary = "Node.js virtual environment builder"
+groups = ["dev", "tests"]
+files = [
+    {file = "nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827"},
+    {file = "nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb"},
+]
+
+[[package]]
 name = "numcodecs"
 version = "0.13.1"
 requires_python = ">=3.10"
@@ -1847,6 +1858,21 @@ groups = ["dev", "docs", "tests"]
 files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
     {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.408"
+requires_python = ">=3.7"
+summary = "Command line wrapper for pyright"
+groups = ["dev", "tests"]
+dependencies = [
+    "nodeenv>=1.6.0",
+    "typing-extensions>=4.1",
+]
+files = [
+    {file = "pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1"},
+    {file = "pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ tests = [
     "pytest-cov<5.0.0,>=4.1.0",
     "coveralls<4.0.0,>=3.3.1",
     "mypy>=1.17.1",
+    "pyright>=1.1.408",
 ]
 docs = [
     "numpydantic[arrays]",
@@ -147,7 +148,8 @@ markers = [
     "union: union dtypes",
     "pipe_union: union dtypes specified with a pipe",
     "scalar: scalar values",
-    "model: dtype annotatiosn are a pydantic model"
+    "model: dtype annotatiosn are a pydantic model",
+    "typechecking: type checker integration - mypy, pyright"
 ]
 
 [tool.black]

--- a/src/numpydantic/__init__.py
+++ b/src/numpydantic/__init__.py
@@ -5,7 +5,8 @@
 from numpydantic.ndarray import NDArray
 from numpydantic.meta import update_ndarray_stub
 from numpydantic.validation.shape import Shape
+from numpydantic.annotation import NDArraySchema
 
 update_ndarray_stub()
 
-__all__ = ["NDArray", "Shape"]
+__all__ = ["NDArray", "NDArraySchema", "Shape"]

--- a/src/numpydantic/annotation.py
+++ b/src/numpydantic/annotation.py
@@ -26,22 +26,25 @@ def NDArraySchema(
 
     Examples:
 
-        from typing import Annotated as A
-        from numpydantic import Shape, NDArraySchema
-        import numpy as np
-        from pydantic import BaseModel
+        >>> from typing import Annotated as A
+        >>> from numpydantic import Shape, NDArraySchema
+        >>> import numpy as np
+        >>>f rom pydantic import BaseModel
 
-        class MyModel(BaseModel):
-            array: A[np.ndarray, NDArraySchema(Shape(3, 3), np.uint8)]
+        >>> class MyModel(BaseModel):
+        >>>     array: A[np.ndarray, NDArraySchema(Shape(3, 3), np.uint8)]
 
-        # or, without Shape
-        class MyOtherModel(BaseModel):
-            array: A[np.ndarray, NDArraySchema((3, 3), np.uint8)]
+        or, without Shape
+        
+        >>> class MyOtherModel(BaseModel):
+        >>>     array: A[np.ndarray, NDArraySchema((3, 3), np.uint8)]
 
-        # valid
+        Valid:
+        
         >>> MyModel(array=np.ones((3, 3), dtype=np.uint8))
 
-        # not valid
+        Not valid:
+        
         >>> MyModel(array=dask.array.ones((3, 3), dtype=np.uint8))
 
     Args:

--- a/src/numpydantic/annotation.py
+++ b/src/numpydantic/annotation.py
@@ -1,0 +1,58 @@
+"""
+A :class:`pydantic.GetPydanticCoreSchema` - like type annotation
+to make type checkers happy :)
+"""
+
+from typing import Any
+
+from pydantic import GetPydanticSchema
+
+from numpydantic import NDArray
+from numpydantic.types import DtypeType
+from numpydantic.validation.shape import Shape
+
+
+def NDArraySchema(
+    shape: type[Shape] | Shape | str | tuple = Shape, dtype: DtypeType = Any
+) -> GetPydanticSchema:
+    """
+    Specify shape and dtype constraints in an :class:`typing.Annotated` type.
+
+    In addition to validating dtype and shape constraints,
+    the ``type`` of the array will also be validated -
+    i.e. if the annotation is for a :class:`numpy.ndarray`,
+    a :class:`dask.array.Array` will be rejected
+    even if it has the correct shape and dtype.
+
+    Examples:
+
+        from typing import Annotated as A
+        from numpydantic import Shape, NDArraySchema
+        import numpy as np
+        from pydantic import BaseModel
+
+        class MyModel(BaseModel):
+            array: A[np.ndarray, NDArraySchema(Shape(3, 3), np.uint8)]
+
+        # or, without Shape
+        class MyOtherModel(BaseModel):
+            array: A[np.ndarray, NDArraySchema((3, 3), np.uint8)]
+
+        # valid
+        >>> MyModel(array=np.ones((3, 3), dtype=np.uint8))
+
+        # not valid
+        >>> MyModel(array=dask.array.ones((3, 3), dtype=np.uint8))
+
+    Args:
+        shape (Shape | str | tuple): The shape specification, either as a Shape class,
+            or as the shape constraint string/tuple by itself.
+        dtype:
+
+    Returns:
+
+    """
+    if shape is not Shape and not issubclass(shape, Shape):
+        shape = Shape[shape]
+
+    return GetPydanticSchema(NDArray[shape, dtype].__get_pydantic_core_schema__)

--- a/src/numpydantic/annotation.py
+++ b/src/numpydantic/annotation.py
@@ -35,16 +35,16 @@ def NDArraySchema(
         >>>     array: A[np.ndarray, NDArraySchema(Shape(3, 3), np.uint8)]
 
         or, without Shape
-        
+
         >>> class MyOtherModel(BaseModel):
         >>>     array: A[np.ndarray, NDArraySchema((3, 3), np.uint8)]
 
         Valid:
-        
+
         >>> MyModel(array=np.ones((3, 3), dtype=np.uint8))
 
         Not valid:
-        
+
         >>> MyModel(array=dask.array.ones((3, 3), dtype=np.uint8))
 
     Args:

--- a/src/numpydantic/annotation.py
+++ b/src/numpydantic/annotation.py
@@ -29,7 +29,7 @@ def NDArraySchema(
         >>> from typing import Annotated as A
         >>> from numpydantic import Shape, NDArraySchema
         >>> import numpy as np
-        >>>f rom pydantic import BaseModel
+        >>> from pydantic import BaseModel
 
         >>> class MyModel(BaseModel):
         >>>     array: A[np.ndarray, NDArraySchema(Shape(3, 3), np.uint8)]

--- a/src/numpydantic/ndarray.py
+++ b/src/numpydantic/ndarray.py
@@ -13,7 +13,7 @@ Extension of nptyping NDArray for pydantic that allows for JSON-Schema serializa
 
 """
 
-from typing import TYPE_CHECKING, Any, Literal, get_origin
+from typing import TYPE_CHECKING, Any, Literal, Union, get_origin
 
 import numpy as np
 from pydantic import GetJsonSchemaHandler
@@ -40,12 +40,12 @@ from numpydantic.vendor.nptyping.typing_ import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover
-    from nptyping.base_meta_classes import SubscriptableMeta
     from pydantic._internal._schema_generation_shared import (
         CallbackGetCoreSchemaHandler,
     )
 
     from numpydantic import Shape
+    from numpydantic.vendor.nptyping.base_meta_classes import SubscriptableMeta
 
 
 class NDArrayMeta(_NDArrayMeta, implementation="NDArray"):
@@ -181,24 +181,42 @@ class NDArray(NPTypingType, metaclass=NDArrayMeta):
     @classmethod
     def __get_pydantic_core_schema__(
         cls,
-        _source_type: "NDArray",
+        _source_type: Union["NDArray", Any],
         _handler: "CallbackGetCoreSchemaHandler",
     ) -> core_schema.CoreSchema:
-        shape, dtype = _source_type.__args__
+        shape, dtype = cls.__args__
         shape: ShapeType
         dtype: DtypeType
+
+        serialization = core_schema.plain_serializer_function_ser_schema(
+            jsonize_array, when_used="json", info_arg=True
+        )
 
         # make core schema for json schema, store it and any model definitions
         # so that we can use them when rendering json schema
         json_schema = make_json_schema(shape, dtype, _handler)
 
-        return core_schema.with_info_plain_validator_function(
-            get_validate_interface(shape, dtype),
-            serialization=core_schema.plain_serializer_function_ser_schema(
-                jsonize_array, when_used="json", info_arg=True
-            ),
-            metadata=json_schema,
-        )
+        if (
+            not hasattr(_source_type, "__class__")
+            or _source_type.__class__ is not NDArrayMeta
+        ):
+            return core_schema.chain_schema(
+                [
+                    core_schema.is_instance_schema(_source_type),
+                    core_schema.with_info_plain_validator_function(
+                        get_validate_interface(shape, dtype)
+                    ),
+                ],
+                serialization=serialization,
+                metadata=json_schema,
+            )
+        else:
+
+            return core_schema.with_info_plain_validator_function(
+                get_validate_interface(shape, dtype),
+                serialization=serialization,
+                metadata=json_schema,
+            )
 
     @classmethod
     def __get_pydantic_json_schema__(

--- a/src/numpydantic/validation/shape.py
+++ b/src/numpydantic/validation/shape.py
@@ -42,20 +42,22 @@ from numpydantic.vendor.nptyping.typing_ import ShapeExpression, ShapeTuple
 T = TypeVar("T", bound=Literal[str])
 
 
-class ShapeMeta(ContainerMeta, implementation="Shape"):
+class ShapeMeta(ContainerMeta["Shape"], implementation="Shape"):
     """
     Metaclass that is coupled to nptyping.Shape.
 
     Overridden from nptyping to use local shape validation function
     """
 
-    def _validate_expression(cls, item: str) -> None:
-        validate_shape_expression(item)
+    def _validate_expression(cls, item: str) -> str:
+        return validate_shape_expression(item)
 
     def _normalize_expression(cls, item: str) -> str:
         return normalize_shape_expression(item)
 
     def _get_additional_values(cls, item: Any) -> dict[str, Any]:
+        if isinstance(item, tuple):
+            item = ", ".join(str(i) for i in item)
         dim_strings = get_dimensions(item)
         dim_string_without_labels = remove_labels(dim_strings)
         return {"prepared_args": dim_string_without_labels}
@@ -79,16 +81,34 @@ class Shape(NPTypingType, ABC, Generic[T], metaclass=ShapeMeta):
     >>> Shape['2, 2'] == Literal['2, 2']
     True
 
+    A Shape can be constructed by calling for type checker compatibility
+
+    >>> Shape['2, 2'] == Shape('2, 2')
+
+    And its arguments can be pased as *args, with ints and strings as appropriate
+
+    >>> Shape(2, 2, "...") == Shape("2, 2, ...")
+
     """
+
+    def __new__(cls, *args: str | int) -> type["Shape"]:
+        """Create a new Shape as a callable"""
+        return Shape[args]
 
     __args__ = ("*, ...",)
     prepared_args = ("*", "...")
 
 
-def validate_shape_expression(shape_expression: ShapeExpression | Any) -> None:
+def validate_shape_expression(
+    shape_expression: ShapeExpression | tuple[str, ...] | Any,
+) -> str:
     """
-    CHANGES FROM NPTYPING: Allow ranges
+    CHANGES FROM NPTYPING:
+    - Allow ranges
+    - Allow specifying as a tuple
     """
+    if isinstance(shape_expression, tuple):
+        shape_expression = ", ".join(str(term) for term in shape_expression)
     shape_expression_no_quotes = shape_expression.replace("'", "").replace('"', "")
     if shape_expression is not Any and not re.match(
         _REGEX_SHAPE_EXPRESSION, shape_expression_no_quotes
@@ -96,6 +116,7 @@ def validate_shape_expression(shape_expression: ShapeExpression | Any) -> None:
         raise InvalidShapeError(
             f"'{shape_expression}' is not a valid shape expression."
         )
+    return shape_expression
 
 
 @lru_cache

--- a/src/numpydantic/vendor/nptyping/base_meta_classes.py
+++ b/src/numpydantic/vendor/nptyping/base_meta_classes.py
@@ -27,12 +27,14 @@ from inspect import getframeinfo
 from types import FrameType
 from typing import (
     Any,
+    Generic,
     TypeVar,
 )
 
-from numpydantic.vendor.nptyping.error import InvalidArgumentsError, NPTypingError
+from numpydantic.vendor.nptyping.error import NPTypingError
 
 _T = TypeVar("_T")
+_TType = TypeVar("_TType", bound=type)
 
 
 class InconstructableMeta(ABCMeta):
@@ -100,7 +102,7 @@ class PrintableMeta(ABCMeta):
         return str(cls)
 
 
-class SubscriptableMeta(ABCMeta):
+class SubscriptableMeta(ABCMeta, Generic[_TType]):
     """
     Makes a class subscriptable: it accepts arguments between brackets and a
     new type is returned for every unique set of arguments.
@@ -129,7 +131,7 @@ class SubscriptableMeta(ABCMeta):
         # values that are to be set as attributes on the new type.
         return {}
 
-    def __getitem__(cls, item: Any) -> type:
+    def __getitem__(cls, item: Any) -> _TType:
         if getattr(cls, "_parameterized", False):
             raise NPTypingError(f"Type nptyping.{cls} is already parameterized.")
 
@@ -175,11 +177,10 @@ class ComparableByArgsMeta(ABCMeta):
 
 
 class ContainerMeta(
-    InconstructableMeta,
     FinalMeta,
     MaybeCheckableMeta,
     PrintableMeta,
-    SubscriptableMeta,
+    SubscriptableMeta[_TType],
     ComparableByArgsMeta,
     ABCMeta,
 ):
@@ -187,29 +188,24 @@ class ContainerMeta(
     Base meta class for "containers" such as Shape and Structure.
     """
 
-    _known_expressions: set[str] = set()
+    _known_expressions: dict[str, str | tuple] = dict()
     __args__: tuple[str, ...]
 
     @abstractmethod
-    def _validate_expression(cls, item: str) -> None: ...  # pragma: no cover
+    def _validate_expression(cls, item: str) -> str: ...  # pragma: no cover
 
     @abstractmethod
     def _normalize_expression(cls, item: str) -> str: ...  # pragma: no cover
 
     def _get_item(cls, item: Any) -> tuple[Any, ...]:
-        if not isinstance(item, str):
-            raise InvalidArgumentsError(
-                f"Unexpected argument of type {type(item)}, expecting a string."
-            )
-
         if item in cls._known_expressions:
             # No need to do costly validations and normalizations if it has been done
             # before.
-            return (item,)
+            return (cls._known_expressions[item],)
 
-        cls._validate_expression(item)
+        item = cls._validate_expression(item)
         norm_shape_expression = cls._normalize_expression(item)
-        cls._known_expressions.add(norm_shape_expression)
+        cls._known_expressions[item] = norm_shape_expression
         return (norm_shape_expression,)
 
     def __subclasscheck__(cls, subclass: Any) -> bool:

--- a/tests/data/mypy/annotation.py
+++ b/tests/data/mypy/annotation.py
@@ -1,4 +1,4 @@
-from typing import Annotated, reveal_type
+from typing import Annotated
 
 import numpy as np
 from pydantic import BaseModel
@@ -26,5 +26,3 @@ def needs_array(x: np.ndarray) -> np.ndarray:
 
 
 needs_array(instance.array)
-
-reveal_type(instance.array)

--- a/tests/data/mypy/annotation.py
+++ b/tests/data/mypy/annotation.py
@@ -1,0 +1,30 @@
+from typing import Annotated, reveal_type
+
+import numpy as np
+from pydantic import BaseModel
+
+from numpydantic import NDArraySchema, Shape
+
+
+class MyModel(BaseModel):
+    array: Annotated[np.ndarray, NDArraySchema(Shape(3, 3), np.uint8)]
+
+
+class MyModel2(BaseModel):
+    array: Annotated[np.ndarray, NDArraySchema(Shape[3, 3], np.uint8)]
+
+
+instance = MyModel(array=np.ones((3, 3), np.uint8))
+
+instance.array = instance.array + 3
+
+assert isinstance(instance.array, np.ndarray)
+
+
+def needs_array(x: np.ndarray) -> np.ndarray:
+    return x
+
+
+needs_array(instance.array)
+
+reveal_type(instance.array)

--- a/tests/data/mypy/numpy_ndarray.py
+++ b/tests/data/mypy/numpy_ndarray.py
@@ -8,7 +8,7 @@ from numpydantic import NDArray, Shape
 x: NDArray[Shape[L["1"]], Any] = np.empty((1,))
 
 
-def a_func(array: np.typing.NDArray) -> None:
+def a_func(array: np.ndarray) -> None:
     pass
 
 

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -9,6 +9,9 @@ from numpydantic.meta import update_ndarray_stub
 MYPY_DIR = Path(__file__).parent / "data" / "mypy"
 
 
+pytestmark = pytest.mark.typechecking
+
+
 @pytest.fixture(scope="session", autouse=True)
 def refresh_stubs():
     """Ensure no stale stubs"""
@@ -31,4 +34,6 @@ def refresh_stubs():
 def test_mypy(test_file: Path):
     """The mypy examples should pass static type checking"""
     res = mypy.api.run([str(test_file)])
-    assert res == ("Success: no issues found in 1 source file\n", "", 0)
+    assert "Success: no issues found in 1 source file" in res[0]
+    assert res[1] == ""
+    assert res[2] == 0

--- a/tests/test_ndarray.py
+++ b/tests/test_ndarray.py
@@ -1,6 +1,7 @@
 import json
-from typing import Any
+from typing import Annotated, Any
 
+import dask.array
 import numpy as np
 import pytest
 from pydantic import (
@@ -9,7 +10,7 @@ from pydantic import (
     ValidationError,
 )
 
-from numpydantic import NDArray, Shape, dtype
+from numpydantic import NDArray, NDArraySchema, Shape, dtype
 from numpydantic.dtype import Number
 from numpydantic.exceptions import DtypeError
 
@@ -396,3 +397,46 @@ def test_callable():
 
     with pytest.raises(DtypeError):
         _ = annotation(np.zeros((1, 2, 3)))
+
+
+def test_annotation():
+    """
+    The NDArraySchema can be used as a type annotation
+    """
+
+    class MyModel(BaseModel):
+        array: Annotated[np.ndarray, NDArraySchema(Shape("3, 3"), np.uint8)]
+
+    MyModel(array=np.ones((3, 3), dtype=np.uint8))
+    with pytest.raises(ValidationError):
+        MyModel(array=np.ones((4, 4), dtype=np.uint8))
+    with pytest.raises(ValidationError):
+        MyModel(array=np.ones((3, 3), dtype=np.uint16))
+
+
+def test_annotation_rejects_array_type():
+    """
+    The NDArraySchema also validates that the annotated array type is used,
+    rather than any array type
+    """
+
+    class MyModel(BaseModel):
+        array: Annotated[np.ndarray, NDArraySchema(Shape("3, 3"), np.uint8)]
+
+    with pytest.raises(ValidationError) as e:
+        MyModel(array=dask.array.zeros(shape=(3, 3), dtype=np.uint8))
+
+    err_json = json.loads(e.value.json())
+    assert err_json[0]["type"] == "is_instance_of"
+
+
+@pytest.mark.parametrize("shape", ("1, 2, 3, ...", (1, 2, 3, "...")))
+def test_annotation_allows_not_using_shape(shape):
+    """
+    Annotation can not use the Shape class
+    """
+
+    class MyModel(BaseModel):
+        array: Annotated[np.ndarray, NDArraySchema(shape, np.uint8)]
+
+    MyModel(array=np.ones(shape=(1, 2, 3), dtype=np.uint8))

--- a/tests/test_pyright.py
+++ b/tests/test_pyright.py
@@ -1,0 +1,18 @@
+import subprocess
+from pathlib import Path
+
+import pyright
+import pytest
+
+MYPY_DIR = Path(__file__).parent / "data" / "mypy"
+
+pytestmark = pytest.mark.typechecking
+
+
+@pytest.mark.parametrize("test_file", MYPY_DIR.glob("*.py"))
+def test_pyright(test_file: Path):
+    """The mypy examples should pass static type checking"""
+    res = pyright.run(
+        "--outputjson", str(test_file), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    assert res.returncode == 0, f"stderr:\n{res.stderr}\n\nstdout:\n{res.stdout}"

--- a/tests/test_pyright.py
+++ b/tests/test_pyright.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.typechecking
 
 @pytest.mark.parametrize("test_file", MYPY_DIR.glob("*.py"))
 def test_pyright(test_file: Path):
-    """The mypy examples should pass static type checking"""
+    """The mypy examples should pass static type checking with pyright too"""
     res = pyright.run(
         "--outputjson", str(test_file), stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -95,3 +95,29 @@ def test_shape_literal():
     # fails to validate
     with pytest.raises(ShapeError):
         _ = array_type(np.zeros((4, 5)))
+
+
+def test_shape_callable():
+    """Shape can be used as a callable rather than a bracketed type"""
+    array_type = NDArray[Shape("1, 2, ..."), Any]
+
+    # validates
+    _ = array_type(np.zeros((1, 2, 3)))
+    # fails to validate
+    with pytest.raises(ShapeError):
+        _ = array_type(np.zeros((4, 5)))
+
+
+@pytest.mark.parametrize("form", ["square", "round"])
+def test_shape_tuple(form: str):
+    """Shape can be given as a tuple as well!"""
+    if form == "square":
+        array_type = NDArray[Shape[1, 2, "..."], Any]
+    else:
+        array_type = NDArray[Shape(1, 2, "..."), Any]
+
+    # validates
+    _ = array_type(np.zeros((1, 2, 3)))
+    # fails to validate
+    with pytest.raises(ShapeError):
+        _ = array_type(np.zeros((4, 5)))


### PR DESCRIPTION
Fix: #41 
Fix: #62 

Any by "fix those issues" i mean "provides a way to use numpydantic that fixes those issues with a mildly different syntax.

This PR provides a `NDArraySchema()` function that is a thin wrapper around pydantic 'GetPydanticSchema' annotation decorator that lets you specify shape and dtype constraints as an annotated type:

```python
class MyModel(BaseModel):
    array: Annotated[np.ndarray, NDArraySchema((1, 2, 3), np.uint8)]
```

It also adds a few different ways to specify shapes that are also oriented around making type checkers happy, since they don't usually like the way Shape is a generic that takes a non-typelike thing as a string.

So if you don't want axis labels, you can specify the shape arguments as args

```python
Shape[1, 2, 3, "..."]
```

Or you can call Shape as a callable

```python
Shape(1, 2, 3, "...")
Shape("1, 2, 3, ...")
```

And, when using the annotation, you can omit the `Shape` altogether (as above)