### PR TITLE
fix(`ndarray`): implement `__subclasscheck__` for ABC protocol compliance

### DIFF
--- a/src/numpydantic/ndarray.py
+++ b/src/numpydantic/ndarray.py
@@ -87,6 +87,34 @@ class NDArrayMeta(_NDArrayMeta, implementation="NDArray"):
         except InterfaceError:
             return False
 
+    def __subclasscheck__(cls, subclass: Any) -> bool:
+        """
+        Override of base method to return False if the subclass is not a subclass of NDArrayMeta.
+
+        Args:
+            subclass: The subclass to check.
+
+        Returns:
+            bool: ``True`` if the subclass is a subclass of NDArrayMeta, ``False`` otherwise.
+        """
+
+        if not isinstance(
+            subclass, NDArrayMeta
+        ):  # Return False if the subclass is not a subclass of NDArrayMeta.
+            return False
+
+        # If both subclasses are NDArrayMeta, check if the __args__ are the same.
+        cls_shape, cls_dtype = cls.__args__
+        sub_shape, sub_dtype = subclass.__args__
+        shape_match = cls_shape is Any or (
+            sub_shape is not Any and issubclass(sub_shape, cls_shape)
+        )
+        dtype_match = cls_dtype is Any or (
+            sub_dtype is not Any and issubclass(sub_dtype, cls_dtype)
+        )
+
+        return shape_match and dtype_match
+
     def _is_literal_like(cls, item: Any) -> bool:
         """
         Changes from nptyping:
@@ -211,7 +239,6 @@ class NDArray(NPTypingType, metaclass=NDArrayMeta):
                 metadata=json_schema,
             )
         else:
-
             return core_schema.with_info_plain_validator_function(
                 get_validate_interface(shape, dtype),
                 serialization=serialization,

--- a/src/numpydantic/vendor/nptyping/ndarray.py
+++ b/src/numpydantic/vendor/nptyping/ndarray.py
@@ -92,6 +92,34 @@ class NDArrayMeta(
             )
         )
 
+    def __subclasscheck__(cls, subclass: Any) -> bool:
+        """
+        Override of base method to return False if the subclass is not a subclass of NDArrayMeta.
+
+        Args:
+            subclass: The subclass to check.
+
+        Returns:
+            bool: ``True`` if the subclass is a subclass of NDArrayMeta, ``False`` otherwise.
+        """
+
+        if not isinstance(
+            subclass, NDArrayMeta
+        ):  # Return False if the subclass is not a subclass of NDArrayMeta.
+            return False
+
+        # If both subclasses are NDArrayMeta, check if the __args__ are the same.
+        cls_shape, cls_dtype = cls.__args__
+        sub_shape, sub_dtype = subclass.__args__
+        shape_match = cls_shape is Any or (
+            sub_shape is not Any and issubclass(sub_shape, cls_shape)
+        )
+        dtype_match = cls_dtype is Any or (
+            sub_dtype is not Any and issubclass(sub_dtype, cls_dtype)
+        )
+
+        return shape_match and dtype_match
+
     def __str__(cls) -> str:
         shape, dtype = cls.__args__
         return (


### PR DESCRIPTION
## Summary
This PR improves `NDArrayMeta` to comply with Python’s ABC protocol and prevent errors during subclass checks.

## Changes
- Implement `__subclasscheck__` to safely handle `issubclass()` calls with non-`NDArrayMeta` types.
- Add structural subclass comparison based on `shape` and `dtype` constraints.
- Ensure compatibility with external libraries that rely on ABC registration and subclass checks.

## Related Issue
Closes #66 

## Notes
* This change avoids `NPTypingError` when `issubclass()` is used with unrelated types.

## Test
* Verified that `issubclass()` no longer raises errors for non-`NDArray` types.