### PR TITLE
allow proxies to be used with ndarray schema as input

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,25 @@
 
 ### 1.8.*
 
+#### 1.8.1 - 26-04-13
+
+**Added**
+
+- [#67](https://github.com/p2p-ld/numpydantic/pull/67) -
+  When using `NDArraySchema` with one of the Proxy classes (like VideoProxy, HDF5Proxy),
+  allow their nonstandard input types to be used:
+  e.g. allow a Path to be used for a `VideoProxy` annotation like
+
+  ```python
+  class MyModel(BaseModel):
+      video: Annotated[VideoProxy, NDArraySchema()]
+  
+  instance = MyModel(video=Path("some_video.avi"))
+  ```
+  
+  Create a `Proxy` class that provides a reference to the interface that the proxy is for,
+  and then use the interface's input types in the instancecheck.
+
 #### 1.8.0 - 26-02-26
 
 **Version Support**

--- a/src/numpydantic/interface/hdf5.py
+++ b/src/numpydantic/interface/hdf5.py
@@ -48,7 +48,7 @@ from typing import Any, NamedTuple, TypeVar
 import numpy as np
 from pydantic import SerializationInfo
 
-from numpydantic.interface.interface import Interface, JsonDict
+from numpydantic.interface.interface import Interface, JsonDict, Proxy
 from numpydantic.types import DtypeType, NDArrayType
 
 try:
@@ -91,7 +91,7 @@ class H5JsonDict(JsonDict):
         )
 
 
-class H5Proxy:
+class H5Proxy(Proxy):
     """
     Proxy class to mimic numpy-like array behavior with an HDF5 array
 
@@ -126,6 +126,11 @@ class H5Proxy:
         self.field = field
         self._annotation_dtype = annotation_dtype
         self._h5arraypath = H5ArrayPath(self.file, self.path, self.field)
+
+    @classmethod
+    def proxy_for(cls) -> type[Interface]:
+        """Declare this class as a proxy for the H5Interface"""
+        return H5Interface
 
     def array_exists(self) -> bool:
         """Check that there is in fact an array at :attr:`.path` within :attr:`.file`"""

--- a/src/numpydantic/interface/interface.py
+++ b/src/numpydantic/interface/interface.py
@@ -598,3 +598,19 @@ class Interface(ABC, Generic[T]):
         return InterfaceMark(
             module=interface_module, cls=cls.__name__, name=cls.name, version=v
         )
+
+
+class Proxy(ABC):
+    """
+    A proxy class that exposes some non-array data source (like a video) as an array
+    """
+
+    @classmethod
+    @abstractmethod
+    def proxy_for(cls) -> type[Interface]:
+        """
+        Declare the interface that this is a proxy for,
+        allowing the proxy to be used with the NDArraySchema annotation
+        with any of the input types that the Interface supports.
+        """
+        raise NotImplementedError()

--- a/src/numpydantic/interface/video.py
+++ b/src/numpydantic/interface/video.py
@@ -58,6 +58,11 @@ class VideoProxy:
         self._shape = None  # type: Optional[Tuple[int, ...]]
         self._sample_frame = None  # type: Optional[np.ndarray]
 
+    @classmethod
+    def proxy_for(cls) -> type["VideoInterface"]:
+        """Declare this class as a proxy for the VideoInterface"""
+        return VideoInterface
+
     @property
     def video(self) -> VideoCapture:
         """Opened video capture object"""

--- a/src/numpydantic/ndarray.py
+++ b/src/numpydantic/ndarray.py
@@ -200,9 +200,20 @@ class NDArray(NPTypingType, metaclass=NDArrayMeta):
             not hasattr(_source_type, "__class__")
             or _source_type.__class__ is not NDArrayMeta
         ):
+            if hasattr(_source_type, "proxy_for"):
+                interface: type[Interface] = _source_type.proxy_for()
+                isinstance_schema = core_schema.union_schema(
+                    [
+                        core_schema.is_instance_schema(itype)
+                        for itype in list(interface.input_types) + [_source_type]
+                    ]
+                )
+            else:
+                isinstance_schema = core_schema.is_instance_schema(_source_type)
+
             return core_schema.chain_schema(
                 [
-                    core_schema.is_instance_schema(_source_type),
+                    isinstance_schema,
                     core_schema.with_info_plain_validator_function(
                         get_validate_interface(shape, dtype)
                     ),
@@ -211,7 +222,6 @@ class NDArray(NPTypingType, metaclass=NDArrayMeta):
                 metadata=json_schema,
             )
         else:
-
             return core_schema.with_info_plain_validator_function(
                 get_validate_interface(shape, dtype),
                 serialization=serialization,

--- a/tests/test_interface/test_video.py
+++ b/tests/test_interface/test_video.py
@@ -3,12 +3,13 @@ Needs to be refactored to DRY, but works for now
 """
 
 from pathlib import Path
+from typing import Annotated as A
 
 import cv2
 import pytest
 from pydantic import BaseModel, ValidationError
 
-from numpydantic import NDArray, Shape
+from numpydantic import NDArray, NDArraySchema, Shape
 from numpydantic import dtype as dt
 from numpydantic.interface.video import VideoProxy
 
@@ -196,3 +197,17 @@ def test_video_proxy_eq(comparison, valid):
     else:
         with pytest.raises(valid):
             assert proxy_a == comparison
+
+
+@pytest.mark.proxy
+def test_path_input_with_proxy_schema(avi_video):
+    """When we use the NDArraySchema and VideoProxy, we can use Path as an input"""
+
+    shape = (100, 50)
+    vid = avi_video(shape=shape, is_color=True)
+
+    class MyModel(BaseModel):
+        array: A[VideoProxy, NDArraySchema(Shape["*", 100, 50, 3], dt.UInt8)]
+
+    instance = MyModel(array=vid)
+    assert instance.array.path == vid


### PR DESCRIPTION
The current impl doesn't let us use our proxy classes with `NDArraySchema` with their convenience input types - e.g. passing a path as an input to `VideoProxy`. That would be really nice to have!

So we make a back reference from the proxy to its interface, which already declares a tuple of input types, and use those in the isinstance schema!

