### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,13 @@
+cff-version: 1.2.0
+message: If you use this software, please cite it as below.
+title: 'Numpydantic: Static and dynamic array constraint validation for data standards and working programmers'
+type: software
+authors:
+- given-names: Jonny L.
+  family-names: Saunders
+  orcid: https://orcid.org/0000-0003-0545-5066
+- given-names: Daniel
+  family-names: Aharoni
+  orcid: https://orcid.org/0000-0003-4931-8514
+repository-code: https://github.com/p2p-ld/numpydantic
+license: MIT


### PR DESCRIPTION
Adds a `CITATION.cff` so GitHub shows a "Cite this repository" button and tools can pick up machine-readable citation metadata.

Author names and ORCIDs are taken from `paper.md`, and the licence from the LICENSE file. Validated with `cffconvert --validate` against schema 1.2.0.

Please check the given-name/family-name split is right for each author, since I derived it from the single `name` field in the paper.

<!-- readthedocs-preview numpydantic start -->
----
📚 Documentation preview 📚: https://numpydantic--79.org.readthedocs.build/en/79/

<!-- readthedocs-preview numpydantic end -->